### PR TITLE
[PLAT-949] make apiserver etcd cert flags optional and default to undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 [![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/k8s.svg)](https://forge.puppet.com/puppet/k8s)
 [![License](https://img.shields.io/github/license/voxpupuli/puppet-k8s.svg)](https://github.com/voxpupuli/puppet-k8s/blob/master/LICENSE)
 
+## Changes from Fork
+
+This fork allows kube-apiserver to start without setting the --etcd-cafile, --etcd-certfile, and --etcd-keyfile flags.
+They are optional and default to `undef` (this default is different from the original module!).
+
 ## Table of Contents
 
 - [Description](#description)

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -50,9 +50,9 @@ class k8s::server::apiserver (
   Stdlib::Unixpath $front_proxy_key        = "${cert_path}/front-proxy-client.key",
   Stdlib::Unixpath $apiserver_client_cert  = "${cert_path}/apiserver-kubelet-client.pem",
   Stdlib::Unixpath $apiserver_client_key   = "${cert_path}/apiserver-kubelet-client.key",
-  Stdlib::Unixpath $etcd_ca                = "${cert_path}/etcd-ca.pem",
-  Stdlib::Unixpath $etcd_cert              = "${cert_path}/etcd.pem",
-  Stdlib::Unixpath $etcd_key               = "${cert_path}/etcd.key",
+  Optional[Stdlib::Unixpath] $etcd_ca      = undef,
+  Optional[Stdlib::Unixpath] $etcd_cert    = undef,
+  Optional[Stdlib::Unixpath] $etcd_key     = undef,
 
   String[1] $container_registry            = $k8s::container_registry,
   String[1] $container_image               = 'kube-apiserver',


### PR DESCRIPTION
Because some of our clusters don't yet use TLS for internal etcd communication, we need to be able to omit these flags on the kube-apiserver service. 

This is a breaking change in that it changes default behavior so we won't attempt to merge this upstream, and we should try to get off of this as soon as possible by migrating to TLS for etcd communication.
