### PR TITLE
[PLAT-1115] add param k8s::server::etcd::setup::enable_v2_api and pas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 
 ## Changes from Fork
 
-This fork allows kube-apiserver to start without setting the --etcd-cafile, --etcd-certfile, and --etcd-keyfile flags.
+- Allows kube-apiserver to start without setting the --etcd-cafile, --etcd-certfile, and --etcd-keyfile flags.
 They are optional and default to `undef` (this default is different from the original module!).
+- Allows enabling the v2 etcd API by setting `k8s::server::etcd::setup::enable_v2_api` to `true`.
 
 ## Table of Contents
 

--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -8,6 +8,7 @@
 # @param cert_file path to the cert file
 # @param client_cert_auth Use client cert auth
 # @param data_dir path to the data dir
+# @param enable_v2_api Enable the v2 api
 # @param ensure set ensure for installation or deinstallation
 # @param etcd_name The etcd instance name
 # @param fqdn fully qualified domain name
@@ -69,6 +70,7 @@ class k8s::server::etcd::setup (
   Optional[Enum['existing', 'new']] $initial_cluster_state = undef,
   Optional[String[1]] $initial_cluster_token               = undef,
   Array[String[1]] $initial_cluster                        = [],
+  Boolean $enable_v2_api                                    = false,
 
   Optional[Stdlib::Unixpath] $binary_path = undef,
   Stdlib::Unixpath $storage_path          = '/var/lib/etcd',
@@ -185,6 +187,7 @@ class k8s::server::etcd::setup (
           auto_compaction_retention   => $auto_compaction_retention,
           initial_cluster_state       => $initial_cluster_state,
           initial_cluster_token       => $initial_cluster_token,
+          enable_v2                   => $enable_v2_api,
       }),
       notify  => Service['etcd'];
 


### PR DESCRIPTION
We need this until we update flannel to use the v3 etcd api (or update it to not use etcd at all)

This feature is already templated out in the etcd.conf.epp template, but the parameter was missing from the puppet class.

Could try to merge this upstream, but would require more work to update docs and things. 
